### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
   },
   "homepage": "https://github.com/gayanhewa/sailsjs-cacheman",
   "dependencies": {
-    "cacheman": "^1.1.0",
+    "cacheman": "2.2.1",
     "cacheman-file": "0.0.8",
     "cacheman-mongo": "^0.2.1",
-    "cacheman-redis": "^0.2.0",
+    "cacheman-redis": "1.1.2",
     "underscore": "^1.8.2"
   }
 }


### PR DESCRIPTION
We had to update versions of cacheman and cacheman-redis to make it work properly because with the old versions there was a problem with duplicate string 'cache' in the key when we tried to clear the cache.
